### PR TITLE
Compatibility fix for node 0.10.x

### DIFF
--- a/tasks/tree.js
+++ b/tasks/tree.js
@@ -113,6 +113,8 @@ module.exports = function(grunt) {
             });
 
             function toTree(abspath, subdir, filename) {
+                // ensure subdir is not undefined
+                subdir = subdir || "";
                 // ignore hidden file
                 if (filename.indexOf('.') === 0) {
                     grunt.log.writeln('Ignore file: ' + filename);


### PR DESCRIPTION
Since node 0.10 path.join() throws an exception for non string arguments.
http://nodejs.org/api/path.html#path_path_join_path1_path2

Patched the `toTree` method to filter non string `subdir`
