### PR TITLE
URL backslash fix + Prettifying JSON + Exclude paths

### DIFF
--- a/tasks/tree.js
+++ b/tasks/tree.js
@@ -188,7 +188,7 @@ module.exports = function(grunt) {
                     if (options.format) {
                         extFileName = getExtFileName(subdir, options.ext, filename);
                     } else {
-                        extFileName = getFileName(filename);
+                        extFileName = getFileName(subdir.replace(/[\\\/\.]+/g,'') + filename);
                     }
                     tree[extFileName] = path.join(options.cwd, subdir, getMd5Name(abspath, filename, options.md5));
                 }


### PR DESCRIPTION
**Fixing url backslashes**
- path.join in windows seems to convert all fordslashes into backslashes, regulating to the system path structure.

**Prettifying JSON**
- Tests were prettified but stopped working, simple patch.

**Added exclude : [path/, ...]**
- Grunt-tree doesn't support "Building the files object dynamically". So in return, excluding files was not available.

```
//To exclude any directory or path, simply add an array of URIs:
options : {
    exclude : [
        'css/style.css',
        'img/',
        'js/bootstrap/secret.js' ]
}
```

_Note: All paths are relative to the "current directory" / "cwd"_
