### PR TITLE
Escaped Path.sep

### DIFF
--- a/tasks/tree.js
+++ b/tasks/tree.js
@@ -14,7 +14,7 @@ var Path = require('path'),
 
 function getUNCPath(file, isUNCPath) {
     if (isUNCPath && Path.sep !== '/') {
-        return file.replace(new RegExp(Path.sep, 'g'), '/');
+        return file.replace(new RegExp('\\' + Path.sep, 'g'), '/');
     } else {
         return file;
     }


### PR DESCRIPTION
`uncpath` now works good on windows.
